### PR TITLE
Omit default Language

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Description: A system for creating the bilateral trade flow between a country
     Yotov, Piermartini, Monteiro and Larch <https://vi.unctad.org/tpa/web/docs/vol2/book.pdf>.
 License: MIT + file LICENSE
 Encoding: UTF-8
-Language: English
 LazyData: true
 LazyDataCompression: xz
 Depends: R (>= 3.5.0)


### PR DESCRIPTION
https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file

WRE mentions `Language:` should only be used if documentation is not in English. The entry should also be an ISO 639 code (like `en`), not the full language name.